### PR TITLE
Fix gallery card action overflow

### DIFF
--- a/codex_image/webui/static/styles.css
+++ b/codex_image/webui/static/styles.css
@@ -7701,7 +7701,7 @@ body.lightbox-open {
 
 .gallery-grid-layer {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 220px), 1fr));
   gap: 14px;
 }
 
@@ -8244,6 +8244,9 @@ body.lightbox-open {
   position: relative;
   display: grid;
   grid-template-rows: auto auto auto auto;
+  container-type: inline-size;
+  min-width: 0;
+  max-width: 100%;
   overflow: hidden;
   border: 1px solid var(--line);
   border-radius: 12px;
@@ -8327,30 +8330,52 @@ body.lightbox-open {
 .gallery-card-body {
   display: grid;
   gap: 6px;
+  min-width: 0;
   min-height: 58px;
   padding: 10px;
 }
 
 .gallery-card-heading {
   display: block;
+  min-width: 0;
 }
 
 .gallery-card-heading strong {
+  display: block;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .gallery-card-body span {
+  min-width: 0;
+  overflow: hidden;
   color: var(--muted);
   font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .gallery-card-actions {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 6px;
+  min-width: 0;
   padding: 0 10px 10px;
+}
+
+.gallery-card-actions .ghost-button {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@container (max-width: 219px) {
+  .gallery-card-actions {
+    grid-template-columns: 1fr;
+  }
 }
 
 .danger-button {

--- a/codex_image/webui/static/styles/70-settings-preview.css
+++ b/codex_image/webui/static/styles/70-settings-preview.css
@@ -2661,7 +2661,7 @@ body.lightbox-open {
 
 .gallery-grid-layer {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 220px), 1fr));
   gap: 14px;
 }
 
@@ -3204,6 +3204,9 @@ body.lightbox-open {
   position: relative;
   display: grid;
   grid-template-rows: auto auto auto auto;
+  container-type: inline-size;
+  min-width: 0;
+  max-width: 100%;
   overflow: hidden;
   border: 1px solid var(--line);
   border-radius: 12px;
@@ -3287,30 +3290,52 @@ body.lightbox-open {
 .gallery-card-body {
   display: grid;
   gap: 6px;
+  min-width: 0;
   min-height: 58px;
   padding: 10px;
 }
 
 .gallery-card-heading {
   display: block;
+  min-width: 0;
 }
 
 .gallery-card-heading strong {
+  display: block;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .gallery-card-body span {
+  min-width: 0;
+  overflow: hidden;
   color: var(--muted);
   font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .gallery-card-actions {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 6px;
+  min-width: 0;
   padding: 0 10px 10px;
+}
+
+.gallery-card-actions .ghost-button {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@container (max-width: 219px) {
+  .gallery-card-actions {
+    grid-template-columns: 1fr;
+  }
 }
 
 .danger-button {


### PR DESCRIPTION
﻿## Summary

Fixes gallery cards clipping their right-side action buttons when the drawer/card becomes narrow or browser zoom changes.

The gallery card layout now lets grid children shrink correctly, truncates long gallery names and category labels, and stacks actions when a card is too narrow for two action columns.

## Root cause

The card grid allowed narrow tracks while long gallery names and action cells still contributed wider min-content sizes. Because gallery cards clip overflow, the right-side action column could be hidden instead of reflowing within the card.

## Verification

- `npm run check:webui`
- `git diff --check`

## Screenshots

Before: gallery action buttons on the right side could be clipped at narrow drawer widths.
<img width="446" height="552" alt="image" src="https://github.com/user-attachments/assets/9e7d5f46-2742-4682-bd1b-dcd10e9c6ebc" />

After: all six actions remain visible, with long labels truncated instead of forcing horizontal overflow.
<img width="464" height="567" alt="image" src="https://github.com/user-attachments/assets/f0533e50-3c25-4be0-ae76-07c7e2d2609c" />
