### PR TITLE
fix(webui): normalize unsupported image input formats

### DIFF
--- a/codex_image/webui/executor_inputs.py
+++ b/codex_image/webui/executor_inputs.py
@@ -3,19 +3,30 @@ from __future__ import annotations
 import asyncio
 import base64
 import mimetypes
+from io import BytesIO
 from pathlib import Path
 from typing import Any
 
 from fastapi import HTTPException
+from PIL import Image, ImageOps, UnidentifiedImageError
 
 from .storage import GalleryStorage, ReferenceAssetStorage, TaskStorage
 from .task_metadata import _dedupe_preserve_order, _gallery_ref_response, _reference_asset_response
+
+_SUPPORTED_REQUEST_IMAGE_MIME_TYPES = {"image/png", "image/jpeg", "image/webp", "image/gif"}
+_PIL_FORMAT_MIME_TYPES = {
+    "GIF": "image/gif",
+    "JPEG": "image/jpeg",
+    "PNG": "image/png",
+    "WEBP": "image/webp",
+}
 
 
 def _file_to_data_url(path: Path, *, mime_type: str | None = None) -> str:
     data = path.read_bytes()
     resolved_mime_type = _image_mime_type(mime_type, path.name, data) or "application/octet-stream"
-    return f"data:{resolved_mime_type};base64,{base64.b64encode(data).decode('ascii')}"
+    request_data, request_mime_type = _request_image_payload(data, resolved_mime_type)
+    return f"data:{request_mime_type};base64,{base64.b64encode(request_data).decode('ascii')}"
 
 
 def _image_mime_type(declared_mime_type: str | None, filename: str, data: bytes) -> str | None:
@@ -25,9 +36,51 @@ def _image_mime_type(declared_mime_type: str | None, filename: str, data: bytes)
         _sniff_image_mime_type(data),
     ]
     for candidate in candidates:
-        if candidate.startswith("image/"):
-            return candidate
+        normalized = _normalize_mime_type(candidate)
+        if normalized.startswith("image/"):
+            return normalized
     return None
+
+
+def _normalize_mime_type(value: str | None) -> str:
+    return str(value or "").split(";", 1)[0].strip().lower()
+
+
+def _request_image_payload(data: bytes, mime_type: str) -> tuple[bytes, str]:
+    normalized_mime_type = _normalize_mime_type(mime_type)
+    detected_mime_type, is_animated, image_was_decoded = _detect_pillow_request_mime_type(data)
+    if detected_mime_type in _SUPPORTED_REQUEST_IMAGE_MIME_TYPES and not (detected_mime_type == "image/gif" and is_animated):
+        return data, detected_mime_type
+    if normalized_mime_type in _SUPPORTED_REQUEST_IMAGE_MIME_TYPES and not image_was_decoded:
+        return data, normalized_mime_type
+    if normalized_mime_type not in _SUPPORTED_REQUEST_IMAGE_MIME_TYPES or detected_mime_type is None or is_animated:
+        return _convert_image_to_png(data), "image/png"
+    return data, normalized_mime_type
+
+
+def _detect_pillow_request_mime_type(data: bytes) -> tuple[str | None, bool, bool]:
+    try:
+        with Image.open(BytesIO(data)) as image:
+            image_format = str(image.format or "").upper()
+            return _PIL_FORMAT_MIME_TYPES.get(image_format), bool(getattr(image, "is_animated", False)), True
+    except (OSError, UnidentifiedImageError):
+        return None, False, False
+
+
+def _convert_image_to_png(data: bytes) -> bytes:
+    try:
+        with Image.open(BytesIO(data)) as image:
+            image.seek(0)
+            converted = ImageOps.exif_transpose(image)
+            if converted.mode in {"P", "LA"} or "transparency" in converted.info:
+                converted = converted.convert("RGBA")
+            elif converted.mode not in {"1", "L", "RGB", "RGBA"}:
+                converted = converted.convert("RGB")
+            buffer = BytesIO()
+            converted.save(buffer, format="PNG")
+            return buffer.getvalue()
+    except (OSError, UnidentifiedImageError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail="Unsupported image type: could not decode image") from exc
 
 
 def _sniff_image_mime_type(data: bytes) -> str | None:

--- a/tests/test_webui_executor_inputs.py
+++ b/tests/test_webui_executor_inputs.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import base64
+import tempfile
+import unittest
+from io import BytesIO
+from pathlib import Path
+
+from fastapi import HTTPException
+from PIL import Image
+
+
+def _decode_data_url(data_url: str) -> tuple[str, bytes]:
+    header, encoded = data_url.split(",", 1)
+    return header, base64.b64decode(encoded)
+
+
+def _jpeg_bytes() -> bytes:
+    buffer = BytesIO()
+    Image.new("RGB", (8, 8), (240, 80, 40)).save(buffer, format="JPEG")
+    return buffer.getvalue()
+
+
+def _mpo_bytes() -> bytes:
+    buffer = BytesIO()
+    first = Image.new("RGB", (8, 8), (240, 80, 40))
+    second = Image.new("RGB", (8, 8), (40, 120, 240))
+    try:
+        first.save(buffer, format="MPO", save_all=True, append_images=[second])
+    except (OSError, KeyError, ValueError) as exc:
+        raise unittest.SkipTest(f"Pillow cannot write MPO fixtures: {exc}") from exc
+    return buffer.getvalue()
+
+
+class WebUIExecutorInputTests(unittest.TestCase):
+    def test_file_to_data_url_converts_mpo_reference_images_to_png(self) -> None:
+        from codex_image.webui.executor_inputs import _file_to_data_url
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "reference.mpo"
+            path.write_bytes(_mpo_bytes())
+
+            data_url = _file_to_data_url(path, mime_type="image/mpo")
+
+        header, payload = _decode_data_url(data_url)
+        self.assertEqual(header, "data:image/png;base64")
+        with Image.open(BytesIO(payload)) as converted:
+            self.assertEqual(converted.format, "PNG")
+            self.assertEqual(converted.size, (8, 8))
+
+    def test_file_to_data_url_uses_actual_supported_image_type_when_declared_type_is_wrong(self) -> None:
+        from codex_image.webui.executor_inputs import _file_to_data_url
+
+        jpeg_data = _jpeg_bytes()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "reference.mpo"
+            path.write_bytes(jpeg_data)
+
+            data_url = _file_to_data_url(path, mime_type="image/mpo")
+
+        header, payload = _decode_data_url(data_url)
+        self.assertEqual(header, "data:image/jpeg;base64")
+        self.assertEqual(payload, jpeg_data)
+
+    def test_file_to_data_url_rejects_undecodable_unsupported_images(self) -> None:
+        from codex_image.webui.executor_inputs import _file_to_data_url
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "broken.heic"
+            path.write_bytes(b"not an image")
+
+            with self.assertRaises(HTTPException) as caught:
+                _file_to_data_url(path, mime_type="image/heic")
+
+        self.assertEqual(caught.exception.status_code, 400)
+        self.assertEqual(caught.exception.detail, "Unsupported image type: could not decode image")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Normalize unsupported reference/edit image inputs before sending them to the image backend.

MPO images can look like ordinary photos but are rejected upstream with `invalid_image_format`. This PR preserves supported image formats and converts decodable unsupported inputs to PNG before constructing request data URLs.

## Changes

- Preserve supported PNG, JPEG, WEBP, and non-animated GIF request inputs.
- Detect the actual image container with Pillow instead of trusting only the declared MIME type or filename.
- Convert MPO and other decodable unsupported image inputs to PNG before submission.
- Return a clear 400 error when an unsupported image cannot be decoded.
- Add focused tests for MPO conversion, incorrect declared MIME, and undecodable unsupported input bytes.

## Why

Users may upload camera images that appear to be normal photos but are stored as MPO or another unsupported container. The previous flow forwarded those bytes directly as `input_image.image_url`, which caused the request to fail before generation or editing could start.

Handling this at the WebUI request payload boundary keeps the upload/gallery/history flows unchanged while avoiding repeated upstream 400 failures for usable images.

## Test Plan

- `.venv/bin/python -m unittest tests.test_webui_executor_inputs -v`
- `.venv/bin/python -m unittest discover -s tests -v`
- `npm run check:webui`

## Notes

No local inputs, outputs, credentials, task databases, logs, or portable bundle artifacts are included in this PR.
