### PR TITLE
release: prepare v0.8.2

### DIFF
--- a/.github/workflows/release-portable.yml
+++ b/.github/workflows/release-portable.yml
@@ -329,7 +329,7 @@ jobs:
           set -euo pipefail
           release_version="${RELEASE_TAG#v}"
           release_summary="$(awk '
-            /^当前版本：/ || /^本版重点：/ {
+            /^(当前版本|受影响平台|必要操作与数据迁移|本版重点)：/ {
               print
               print ""
               next

--- a/README.en.md
+++ b/README.en.md
@@ -197,15 +197,15 @@ http://127.0.0.1:8787/
 ## App packages
 
 Download the current packages from [Downloads / Releases](RELEASES.md), or open
-[GitHub Release v0.8.1](https://github.com/kadevin/ilab-conjure/releases/tag/v0.8.1)
+[GitHub Release v0.8.2](https://github.com/kadevin/ilab-conjure/releases/tag/v0.8.2)
 directly.
 
 New users should choose the standard packages:
 
-1. macOS: download `iLab-GPT-CONJURE-macos-arm64-0.8.1.dmg`
-   for Apple Silicon or `iLab-GPT-CONJURE-macos-x64-0.8.1.dmg`
+1. macOS: download `iLab-GPT-CONJURE-macos-arm64-0.8.2.dmg`
+   for Apple Silicon or `iLab-GPT-CONJURE-macos-x64-0.8.2.dmg`
    for Intel, then drag `iLab GPT CONJURE.app` to Applications.
-2. Windows: download `iLab-GPT-CONJURE-windows-x64_0.8.1.zip`,
+2. Windows: download `iLab-GPT-CONJURE-windows-x64_0.8.2.zip`,
    extract it into a normal user directory, and run `iLab GPT CONJURE.exe`.
 
 Standard packages store user data in `~/Library/Application Support/iLab GPT

--- a/README.md
+++ b/README.md
@@ -146,14 +146,14 @@ http://127.0.0.1:8787/
 ## 应用包下载
 
 当前可用的标准包和一键包见 [下载 / Releases](RELEASES.md)，也可以直接打开
-[GitHub Release v0.8.1](https://github.com/kadevin/ilab-conjure/releases/tag/v0.8.1)。
+[GitHub Release v0.8.2](https://github.com/kadevin/ilab-conjure/releases/tag/v0.8.2)。
 
 新用户建议优先下载标准包：
 
-1. macOS：Apple Silicon 下载 `iLab-GPT-CONJURE-macos-arm64-0.8.1.dmg`，
-   Intel 下载 `iLab-GPT-CONJURE-macos-x64-0.8.1.dmg`，然后把
+1. macOS：Apple Silicon 下载 `iLab-GPT-CONJURE-macos-arm64-0.8.2.dmg`，
+   Intel 下载 `iLab-GPT-CONJURE-macos-x64-0.8.2.dmg`，然后把
    `iLab GPT CONJURE.app` 拖到 Applications。
-2. Windows：下载 `iLab-GPT-CONJURE-windows-x64_0.8.1.zip`，
+2. Windows：下载 `iLab-GPT-CONJURE-windows-x64_0.8.2.zip`，
    解压到普通用户目录，双击 `iLab GPT CONJURE.exe`。
 
 标准包的用户数据会写入 macOS 的

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,32 +1,56 @@
 # 下载 / Releases
 
-当前正式版本：[v0.8.1](https://github.com/kadevin/ilab-conjure/releases/tag/v0.8.1)
+当前正式版本：[v0.8.2](https://github.com/kadevin/ilab-conjure/releases/tag/v0.8.2)
 
 ## 版本说明
 
-当前版本：`v0.8.1`。这是面向 Windows 用户的重要修复版本。建议正在使用 `v0.8.0` 的 Windows 标准版和 portable 一键包用户尽快更新。
+当前版本：`v0.8.2`。这是面向长耗时中转站和紧凑桌面布局的可靠性更新。建议遇到生图超过 10 分钟、瞬时网络失败，或“最近上传”溢出“参考输入”卡片的用户更新；其他 `v0.8.1` 用户可以按需升级。
 
-本版重点：修复部分 Windows 环境无法原子保存设置和任务数据的问题，以及本机代理可能导致生成、编辑、设置保存和任务已读操作返回 `403` 的问题。
+受影响平台：macOS 与 Windows 的标准版和 portable 一键包。升级前请退出旧实例；Windows 标准版仍需手动解压替换，portable 可使用现有更新入口，支持更新助手的 macOS 标准版可按界面提示更新。
+
+必要操作与数据迁移：无需迁移或重置数据。已有设置、任务数据库、历史图库、输入图和输出图会保留；新设置只影响后续开始执行的任务。
+
+本版重点：系统设置新增全局单次生图超时和失败后重试控制，并修复短高度桌面布局中“最近上传”缩略图与删除按钮溢出的问题。
 
 本版详情：
 
-### Windows 用户请更新
+### P1 · 重要
 
-- 修复部分 Windows Python 环境缺少 `os.fchmod` 时，设置或任务数据保存失败并显示 Internal Server Error 的问题。
-- 修复 Windows 使用系统代理、本机代理或代理软件时，转发头可能让本地 WebUI 把正常同源写请求误判为跨源请求的问题。
-- 受影响时，生成、编辑、设置保存和任务已读等操作可能返回 `403 Cross-origin WebUI request rejected`；更新后本地服务不再信任无关代理头，原有同源和仅限本机访问保护保持不变。
-- 标准版用户需要退出旧程序，下载并解压新的 Windows 标准包后替换旧程序文件；portable 用户可以通过托盘菜单检查更新，也可以下载完整一键包覆盖程序文件。
-- 更新不会迁移、重置或删除已有设置、任务数据库、历史图库、输入图和输出图。
+#### 新增
 
-macOS 用户不受上述 Windows 原子写入问题影响；如果当前使用正常，可以按需更新。
+- 可在“系统设置 → 网络”把单次生图请求超时设置为 `1–30` 分钟，默认仍为 `10` 分钟，避免响应较慢的兼容中转站被固定十分钟上限提前终止。
+- 可独立设置可重试瞬时失败后的额外重试次数为 `0–5` 次，默认仍为 `2` 次；永久性请求错误不会因此重复发送。
+- 超时与重试策略统一覆盖所有供应商的生成和编辑，并在任务开始执行时冻结；运行中修改不会改变该任务，每次自动重试都会获得新的完整超时窗口，原有队列级通道故障转移保持不变。
+- 连接检测继续使用独立的 `10` 秒上限且不执行自动重试，避免网络检测被生图策略意外延长。
+
+### P2 · 常规
+
+#### 修复
+
+- 修复短高度桌面布局中“最近上传”缩略图和删除按钮溢出“参考输入”卡片的问题；更新后缩略图会按底部可用高度收缩，触控删除目标和横向滚动仍然可用。
+
+#### 兼容性/安装/打包/更新
+
+- 默认值仍为单次请求 `10` 分钟、失败后重试 `2` 次；已有正数 `CODEX_IMAGE_REQUEST_TIMEOUT_SECONDS` 环境变量会继续生效，直到用户在界面中显式保存超时设置。
+- 本版不新增依赖或数据库迁移。旧版本会忽略新增的本地请求策略字段；如需回退，无需转换已有任务与图片数据。
+
+#### 已知问题
+
+- macOS 标准 DMG 和 portable zip 仍未签名、未 notarize；如果系统拦截启动，请按下方说明使用右键或 Control-click 打开。Windows 标准 ZIP 仍需手动替换程序文件。
+
+### P3 · 低影响
+
+#### 工程与文档
+
+- 同步全部 `14` 种界面语言的请求策略文案、用户文档和设计合同，并补充前后端、队列、缓存资源、响应式布局与无障碍自动验证；发布工作流会把升级建议、受影响平台和数据迁移信息完整带入 GitHub Release 正文。
 
 ## 推荐下载
 
 | 平台 | 推荐给 | 下载 | SHA256 |
 | --- | --- | --- | --- |
-| macOS Apple Silicon | 新用户，M1/M2/M3/M4 | [iLab-GPT-CONJURE-macos-arm64-0.8.1.dmg](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.1/iLab-GPT-CONJURE-macos-arm64-0.8.1.dmg) | [sha256](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.1/iLab-GPT-CONJURE-macos-arm64-0.8.1.dmg.sha256.txt) |
-| macOS Intel | 新用户，Intel x64 | [iLab-GPT-CONJURE-macos-x64-0.8.1.dmg](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.1/iLab-GPT-CONJURE-macos-x64-0.8.1.dmg) | [sha256](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.1/iLab-GPT-CONJURE-macos-x64-0.8.1.dmg.sha256.txt) |
-| Windows x64 | 新用户，Windows 10/11 x64 | [iLab-GPT-CONJURE-windows-x64_0.8.1.zip](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.1/iLab-GPT-CONJURE-windows-x64_0.8.1.zip) | [sha256](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.1/iLab-GPT-CONJURE-windows-x64_0.8.1.zip.sha256.txt) |
+| macOS Apple Silicon | 新用户，M1/M2/M3/M4 | [iLab-GPT-CONJURE-macos-arm64-0.8.2.dmg](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.2/iLab-GPT-CONJURE-macos-arm64-0.8.2.dmg) | [sha256](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.2/iLab-GPT-CONJURE-macos-arm64-0.8.2.dmg.sha256.txt) |
+| macOS Intel | 新用户，Intel x64 | [iLab-GPT-CONJURE-macos-x64-0.8.2.dmg](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.2/iLab-GPT-CONJURE-macos-x64-0.8.2.dmg) | [sha256](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.2/iLab-GPT-CONJURE-macos-x64-0.8.2.dmg.sha256.txt) |
+| Windows x64 | 新用户，Windows 10/11 x64 | [iLab-GPT-CONJURE-windows-x64_0.8.2.zip](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.2/iLab-GPT-CONJURE-windows-x64_0.8.2.zip) | [sha256](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.2/iLab-GPT-CONJURE-windows-x64_0.8.2.zip.sha256.txt) |
 
 标准包数据目录：
 
@@ -39,13 +63,13 @@ macOS 用户不受上述 Windows 原子写入问题影响；如果当前使用�
 
 | 平台 | 适用设备 | 下载 | SHA256 |
 | --- | --- | --- | --- |
-| Windows x64 | Windows 10/11 x64 | [ilab-gpt-conjure_windows_portable_x64_0.8.1.zip](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.1/ilab-gpt-conjure_windows_portable_x64_0.8.1.zip) | [sha256](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.1/ilab-gpt-conjure_windows_portable_x64_0.8.1.zip.sha256.txt) |
-| macOS Apple Silicon | M1/M2/M3/M4 | [ilab-gpt-conjure_macos_portable_arm64_0.8.1.zip](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.1/ilab-gpt-conjure_macos_portable_arm64_0.8.1.zip) | [sha256](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.1/ilab-gpt-conjure_macos_portable_arm64_0.8.1.zip.sha256.txt) |
-| macOS Intel | Intel x64 | [ilab-gpt-conjure_macos_portable_x64_0.8.1.zip](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.1/ilab-gpt-conjure_macos_portable_x64_0.8.1.zip) | [sha256](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.1/ilab-gpt-conjure_macos_portable_x64_0.8.1.zip.sha256.txt) |
+| Windows x64 | Windows 10/11 x64 | [ilab-gpt-conjure_windows_portable_x64_0.8.2.zip](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.2/ilab-gpt-conjure_windows_portable_x64_0.8.2.zip) | [sha256](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.2/ilab-gpt-conjure_windows_portable_x64_0.8.2.zip.sha256.txt) |
+| macOS Apple Silicon | M1/M2/M3/M4 | [ilab-gpt-conjure_macos_portable_arm64_0.8.2.zip](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.2/ilab-gpt-conjure_macos_portable_arm64_0.8.2.zip) | [sha256](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.2/ilab-gpt-conjure_macos_portable_arm64_0.8.2.zip.sha256.txt) |
+| macOS Intel | Intel x64 | [ilab-gpt-conjure_macos_portable_x64_0.8.2.zip](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.2/ilab-gpt-conjure_macos_portable_x64_0.8.2.zip) | [sha256](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.2/ilab-gpt-conjure_macos_portable_x64_0.8.2.zip.sha256.txt) |
 
 portable 自动更新 manifest：
 
-- [latest.json](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.1/latest.json)
+- [latest.json](https://github.com/kadevin/ilab-conjure/releases/download/v0.8.2/latest.json)
 
 使用方式：
 

--- a/codex_image/version.py
+++ b/codex_image/version.py
@@ -1,4 +1,4 @@
 """Shared application version metadata."""
 
-APP_VERSION = "0.8.1"
+APP_VERSION = "0.8.2"
 APP_VERSION_TAG = f"v{APP_VERSION}"

--- a/launcher/Cargo.lock
+++ b/launcher/Cargo.lock
@@ -936,7 +936,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "ilab-conjure-launcher"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "base64",

--- a/launcher/Cargo.toml
+++ b/launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ilab-conjure-launcher"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 rust-version = "1.73"
 description = "System tray launcher for iLab CONJURE."

--- a/tests/test_portable_packaging.py
+++ b/tests/test_portable_packaging.py
@@ -559,7 +559,10 @@ class PortablePackagingTests(unittest.TestCase):
         self.assertIn("GH_REPO: ${{ github.repository }}", text)
         self.assertIn("## 发布说明", text)
         self.assertIn('release_summary="$(awk', text)
-        self.assertIn("/^当前版本：/ || /^本版重点：/", text)
+        self.assertIn(
+            "/^(当前版本|受影响平台|必要操作与数据迁移|本版重点)：/",
+            text,
+        )
         self.assertIn("/^本版详情：/", text)
         self.assertIn("in_details && /^## /", text)
         self.assertIn("${release_summary}", text)


### PR DESCRIPTION
## Summary

- Bump the shared Python and Rust application version from 0.8.1 to 0.8.2.
- Replace current package links in the Chinese/English README and release guide with the 0.8.2 asset contract.
- Build the release inventory from the exact `v0.8.1..ed66e9a` range and classify every delivered item by impact and category.
- Preserve upgrade advice, affected platforms, required actions, migration impact, compatibility notes, and known limitations in both `RELEASES.md` and the GitHub Release body generated by the packaging workflow.
- Keep tag creation, package publishing, and GitHub Release creation outside this PR.

## Release content

### P1 · 重要 / 新增

- Add global per-attempt image request timeout control under **System Settings → Network**: 1–30 minutes, default 10.
- Add an independent retry count after retryable transient failures: 0–5, default 2.
- Apply the frozen policy to generation and editing across all providers; each retry receives a fresh timeout window, while queue-level channel failover remains unchanged.
- Keep connection tests independently bounded to 10 seconds with no automatic retries.

### P2 · 常规 / 修复

- Fix Issue #15: recent-upload thumbnails and delete actions no longer overflow the reference-input card in short desktop layouts; horizontal scrolling and coarse-pointer targets remain available.

### P2 · 常规 / 兼容性与已知问题

- Preserve existing defaults and the positive `CODEX_IMAGE_REQUEST_TIMEOUT_SECONDS` fallback until the user explicitly saves a timeout in the UI.
- No dependency or database migration is required; older versions ignore the new local policy keys.
- macOS packages remain unsigned and not notarized; Windows standard ZIP upgrades remain manual.

### P3 · 低影响 / 工程与文档

- Synchronize 14 locale strings, user/design documentation, generated asset validation, responsive/accessibility coverage, and release-summary extraction.

## Validation

- ✅ GitHub Actions: all 9 checks passed on head `db3afecbb1bb8e5ffea704ffd65cbf65a0a2c17e`, including Python 3.11–3.13, WebUI build, Rust on macOS/Windows, dependency security, Windows runtime lock, and the public export guard.
- ✅ `.venv/bin/python scripts/check-release-contracts.py --release-tag v0.8.2`
- ✅ Release, update-manifest, and workflow extraction contracts: 17 tests passed.
- ✅ Portable packaging contracts: 10 tests passed.
- ✅ Cargo metadata resolves with `--locked`; Rust formatting passes.
- ✅ The exact generated GitHub Release summary includes upgrade advice, affected platforms, migration impact, P1/P2/P3 sections, fixes, and known issues.
- ✅ The repository exposes `ILAB_CONJURE_UPDATE_SIGNING_PRIVATE_KEY_B64`; the `release` environment separately requires approval from `kadevin`.
- ✅ `git diff --check` and public export boundary checks.

## Compatibility, risk, and rollback

- No application data, dependency, provider, credential, prompt, or image format migration.
- Download links intentionally target assets that will exist only after the v0.8.2 release workflow completes.
- Rollback before tagging is a revert of this PR's eventual merge commit.
- After merge, the exact release commit must pass CI before any v0.8.2 tag or publishing workflow is authorized.


